### PR TITLE
Use TODO tests for database transaction tests

### DIFF
--- a/t/36_transaction_errors.t
+++ b/t/36_transaction_errors.t
@@ -16,6 +16,12 @@ my $dbm_factory = new_dbm(
 while ( my $dbm_maker = $dbm_factory->() ) {
     my $db1 = $dbm_maker->();
     ok(!$db1->supports('transactions'), "num_txns<=1 means transactions is not supported");
+    
+    my $todo;
+    if (ref $db1->_get_self->{engine} eq 'DBM::Deep::Engine::DBI') {
+        $todo = 'DBM transactions not yet implemented';
+    }
+    local $TODO = $todo;
 
     throws_ok {
         $db1->begin_work;

--- a/t/36_transaction_errors.t
+++ b/t/36_transaction_errors.t
@@ -17,11 +17,10 @@ while ( my $dbm_maker = $dbm_factory->() ) {
     my $db1 = $dbm_maker->();
     ok(!$db1->supports('transactions'), "num_txns<=1 means transactions is not supported");
     
-    my $todo;
+    local $TODO;
     if (ref $db1->_get_self->{engine} eq 'DBM::Deep::Engine::DBI') {
-        $todo = 'DBM transactions not yet implemented';
+        $TODO = 'DBM transactions not yet implemented';
     }
-    local $TODO = $todo;
 
     throws_ok {
         $db1->begin_work;


### PR DESCRIPTION
This is a simple patch to remove the failures in the transaction error tests when SQLite or MySQL is used during testing. It marks the transaction error tests as TODO tests when the engine being tested is DBI. I didn't think making them pass or removing them was the right option because it is true that the database tests actually do fail because of missing functionality in the DBI module. Because that's called out in the POD, however, I also didn't think it should fail the test suite as a whole.

I received your module as a CPAN Pull Challenge for January, and will be submitting at least one more pull request dealing with the database back end (references are not always properly removed from the database when they are overwritten - I have the fix for this but need to write tests to validate).  Please feel free to give me any feedback on this or any other pull requests I submit if I can/should submit them differently.