### PR TITLE
fix for perl 5.26 not having . in @INC by default

### DIFF
--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 diag "Testing DBM::Deep against Perl $] located at $^X";
 

--- a/t/02_hash.t
+++ b/t/02_hash.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 use Scalar::Util qw( reftype );
 
 use_ok( 'DBM::Deep' );

--- a/t/03_bighash.t
+++ b/t/03_bighash.t
@@ -7,7 +7,8 @@ plan skip_all => "You must set \$ENV{LONG_TESTS} to run the long tests"
     unless $ENV{LONG_TESTS};
 
 use Test::Deep;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/04_array.t
+++ b/t/04_array.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/05_bigarray.t
+++ b/t/05_bigarray.t
@@ -6,7 +6,8 @@ use Test::More;
 plan skip_all => "You must set \$ENV{LONG_TESTS} to run the long tests"
     unless $ENV{LONG_TESTS};
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/06_error.t
+++ b/t/06_error.t
@@ -6,7 +6,8 @@ use warnings FATAL => 'all';
 use Test::More;
 use Test::Exception;
 use Test::Warn;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/07_locking.t
+++ b/t/07_locking.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/08_deephash.t
+++ b/t/08_deephash.t
@@ -6,7 +6,8 @@ use Test::More;
 plan skip_all => "You must set \$ENV{LONG_TESTS} to run the long tests"
     unless $ENV{LONG_TESTS};
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 diag "This test can take up to several minutes to run. Please be patient.";
 

--- a/t/09_deeparray.t
+++ b/t/09_deeparray.t
@@ -6,7 +6,8 @@ use Test::More;
 plan skip_all => "You must set \$ENV{LONG_TESTS} to run the long tests"
     unless $ENV{LONG_TESTS};
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 diag "This test can take up to several minutes to run. Please be patient.";
 

--- a/t/10_largekeys.t
+++ b/t/10_largekeys.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/11_optimize.t
+++ b/t/11_optimize.t
@@ -6,7 +6,8 @@ use Test::More;
 plan skip_all => "Skipping the optimize tests on Win32/cygwin for now."
     if ( $^O eq 'MSWin32' || $^O eq 'cygwin' );
 
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/12_clone.t
+++ b/t/12_clone.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/13_setpack.t
+++ b/t/13_setpack.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Config;
 use Test::More;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/14_filter.t
+++ b/t/14_filter.t
@@ -4,7 +4,8 @@ use warnings FATAL => 'all';
 use Test::More;
 use Test::Deep;
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/15_digest.t
+++ b/t/15_digest.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/16_circular.t
+++ b/t/16_circular.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/17_import.t
+++ b/t/17_import.t
@@ -4,7 +4,8 @@ use warnings FATAL => 'all';
 use Test::More;
 use Test::Deep;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/18_export.t
+++ b/t/18_export.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Deep;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/19_crossref.t
+++ b/t/19_crossref.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/20_tie.t
+++ b/t/20_tie.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/21_tie_access.t
+++ b/t/21_tie_access.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/22_internal_copy.t
+++ b/t/22_internal_copy.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm new_fh );
+use lib 't';
+use common qw( new_dbm new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/23_misc.t
+++ b/t/23_misc.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/24_autobless.t
+++ b/t/24_autobless.t
@@ -9,7 +9,8 @@ use warnings FATAL => 'all';
 }
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/25_tie_return_value.t
+++ b/t/25_tie_return_value.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/26_scalar_ref.t
+++ b/t/26_scalar_ref.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_dbm new_fh );
+use lib 't';
+use common qw( new_dbm new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/27_filehandle.t
+++ b/t/27_filehandle.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 # Need to have an explicit plan in order for the sub-testing to work right.
 #XXX Figure out how to use subtests for that.
@@ -73,7 +74,7 @@ print "ok ", ++\$t, " - and get at stuff in the database\n";
 __END_FH__
 
     # The exec below prevents END blocks from doing this.
-    (my $esc_dir = $t::common::dir) =~ s/(.)/sprintf "\\x{%x}", ord $1/egg;
+    (my $esc_dir = $common::dir) =~ s/(.)/sprintf "\\x{%x}", ord $1/egg;
     print $fh <<__END_FH_AGAIN__;
 use File::Path 'rmtree';
 rmtree "$esc_dir"; 

--- a/t/28_index_sector.t
+++ b/t/28_index_sector.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Deep;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/29_largedata.t
+++ b/t/29_largedata.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/30_already_tied.t
+++ b/t/30_already_tied.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/31_references.t
+++ b/t/31_references.t
@@ -4,7 +4,8 @@ use warnings FATAL => 'all';
 use Test::More;
 use Test::Deep;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 my $dbm_factory = new_dbm();

--- a/t/32_dash_ell.t
+++ b/t/32_dash_ell.t
@@ -6,7 +6,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/33_transactions.t
+++ b/t/33_transactions.t
@@ -4,7 +4,8 @@ use warnings FATAL => 'all';
 use Test::More;
 use Test::Deep;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/34_transaction_arrays.t
+++ b/t/34_transaction_arrays.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Deep;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/35_transaction_multiple.t
+++ b/t/35_transaction_multiple.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Deep;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/36_transaction_errors.t
+++ b/t/36_transaction_errors.t
@@ -5,7 +5,8 @@ use Test::More;
 use Test::Deep;
 use Test::Exception;
 use Test::Warn;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/38_data_sector_size.t
+++ b/t/38_data_sector_size.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 sub do_stuff {
     my ($db) = @_;

--- a/t/39_singletons.t
+++ b/t/39_singletons.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Deep;
-use t::common qw( new_dbm new_fh );
+use lib 't';
+use common qw( new_dbm new_fh );
 
 sub is_undef {
  ok(!defined $_[0] || ref $_[0] eq 'DBM::Deep::Null', $_[1])

--- a/t/40_freespace.t
+++ b/t/40_freespace.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/41_transaction_multilevel.t
+++ b/t/41_transaction_multilevel.t
@@ -1,7 +1,8 @@
 use strict;
 use Test::More;
 use Test::Deep;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/42_transaction_indexsector.t
+++ b/t/42_transaction_indexsector.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Deep;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/43_transaction_maximum.t
+++ b/t/43_transaction_maximum.t
@@ -4,7 +4,8 @@ use warnings FATAL => 'all';
 use Test::More;
 use Test::Deep;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/44_upgrade_db.t
+++ b/t/44_upgrade_db.t
@@ -23,7 +23,8 @@ BEGIN {
 
 plan tests => 351;
 
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 use File::Spec;
 use Test::Deep;
 

--- a/t/45_references.t
+++ b/t/45_references.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/46_blist_reindex.t
+++ b/t/46_blist_reindex.t
@@ -5,7 +5,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/47_odd_reference_behaviors.t
+++ b/t/47_odd_reference_behaviors.t
@@ -5,7 +5,8 @@ use Test::More;
 use Test::Exception;
 use Test::Deep;
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/48_autoexport_after_delete.t
+++ b/t/48_autoexport_after_delete.t
@@ -4,7 +4,8 @@ use warnings FATAL => 'all';
 use Test::More;
 use Test::Deep;
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/50_deletes.t
+++ b/t/50_deletes.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 my $max = 10;
 

--- a/t/52_memory_leak.t
+++ b/t/52_memory_leak.t
@@ -5,7 +5,8 @@ use Test::More;
 
 use_ok( 'DBM::Deep' );
 
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 # RT #77746
 my $dbm_factory = new_dbm();

--- a/t/53_misc_transactions.t
+++ b/t/53_misc_transactions.t
@@ -6,7 +6,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/54_output_punct_vars.t
+++ b/t/54_output_punct_vars.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/55_recursion.t
+++ b/t/55_recursion.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Exception;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 
 use_ok( 'DBM::Deep' );
 

--- a/t/56_unicode.t
+++ b/t/56_unicode.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 use utf8;
 
 use DBM::Deep;

--- a/t/57_old_db.t
+++ b/t/57_old_db.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use File::Spec::Functions 'catfile';
 use Test::More;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 
 use DBM::Deep;
 

--- a/t/58_cache.t
+++ b/t/58_cache.t
@@ -2,7 +2,8 @@ use strict;
 use warnings FATAL => 'all';
 
 use Test::More;
-use t::common qw( new_dbm );
+use lib 't';
+use common qw( new_dbm );
 use utf8;
 
 use DBM::Deep;

--- a/t/97_dump_file.t
+++ b/t/97_dump_file.t
@@ -3,7 +3,8 @@ use warnings FATAL => 'all';
 
 use Test::More;
 use Test::Deep;
-use t::common qw( new_fh );
+use lib 't';
+use common qw( new_fh );
 use utf8;
 
 use_ok( 'DBM::Deep' );

--- a/t/common.pm
+++ b/t/common.pm
@@ -1,5 +1,5 @@
 package # Hide from PAUSE
-    t::common;
+    common;
 
 use strict;
 use warnings FATAL => 'all';


### PR DESCRIPTION
Replaces all `use t::common` with `use lib 't'; use common`, because perl 5.26 doesn't have . in @INC by default and so all the tests fail in environments where the CPAN client doesn't work around that.

Fixes https://github.com/robkinyon/dbm-deep/issues/19