### PR TITLE
Synch with CPAN 2.0016 and remove use of apostrophe as package separator.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for DBM::Deep (ordered by revision number).
 
+2.0016 May 20 15:50:00 2018 PDT
+    - Fix mistake in the previous release that prevented indexing.
+
+2.0015 May 20 14:45:00 2018 PDT
+    - Fix for tests failing on 5.28 (Thanks, Slaven!)
+
 2.0014 Jul 27 22:15:00 2017 EDT
     - Fix for tests failing on 5.26 (Thanks, DrHyde!)
 

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "unknown"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.4214",
+   "generated_by" : "Module::Build version 0.4218",
    "license" : [
       "perl_5"
    ],
@@ -47,7 +47,7 @@
    "provides" : {
       "DBM::Deep" : {
          "file" : "lib/DBM/Deep.pm",
-         "version" : "2.0013"
+         "version" : "2.0016"
       },
       "DBM::Deep::Array" : {
          "file" : "lib/DBM/Deep/Array.pm"
@@ -134,6 +134,6 @@
          "url" : "https://github.com/robkinyon/dbm-deep"
       }
    },
-   "version" : "2.0013",
-   "x_serialization_backend" : "JSON::PP version 2.27202"
+   "version" : "2.0016",
+   "x_serialization_backend" : "JSON::PP version 2.27300"
 }

--- a/lib/DBM/Deep.pm
+++ b/lib/DBM/Deep.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings FATAL => 'all';
 no warnings 'recursion';
 
-our $VERSION = q(2.0016);
+our $VERSION = q(2.0017);
 
 use Scalar::Util ();
 
@@ -647,13 +647,13 @@ sub _warnif {
    # to avoid this hack. warnings.pm did not allow us to specify
    # exactly the call frame we want, so we have to look at the bitmask
    # ourselves.
-   if(  vec $bitmask, $warnings'Offsets{$_[0]}, 1,
-     || vec $bitmask, $warnings'Offsets{all}, 1,
+   if(  vec $bitmask, $warnings::Offsets{$_[0]}, 1,
+     || vec $bitmask, $warnings::Offsets{all}, 1,
      ) {
       my $msg = $_[1] =~ /\n\z/ ? $_[1] : "$_[1] at $file line $line.\n";
       die $msg
-       if  vec $bitmask, $warnings'Offsets{$_[0]}+1, 1,
-        || vec $bitmask, $warnings'Offsets{all}+1, 1;
+       if  vec $bitmask, $warnings::Offsets{$_[0]}+1, 1,
+        || vec $bitmask, $warnings::Offsets{all}+1, 1;
       warn $msg;
    }
   }

--- a/lib/DBM/Deep.pm
+++ b/lib/DBM/Deep.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings FATAL => 'all';
 no warnings 'recursion';
 
-our $VERSION = q(2.0014);
+our $VERSION = q(2.0016);
 
 use Scalar::Util ();
 
@@ -636,21 +636,26 @@ sub clear  { (shift)->CLEAR( @_ )  }
 sub _dump_file {shift->_get_self->_engine->_dump_file;}
 
 sub _warnif {
- # There is, unfortunately, no way to avoid this hack. warnings.pm does not
- # allow us to specify exactly the call frame we want. So, for now, we just
- # look at the bitmask ourselves.
  my $level;
  {
   my($pack, $file, $line, $bitmask) = (caller $level++)[0..2,9];
   redo if $pack =~ /^DBM::Deep(?:::|\z)/;
-  if(  vec $bitmask, $warnings'Offsets{$_[0]}, 1,
-    || vec $bitmask, $warnings'Offsets{all}, 1,
-    ) {
-     my $msg = $_[1] =~ /\n\z/ ? $_[1] : "$_[1] at $file line $line.\n";
-     die $msg
-      if  vec $bitmask, $warnings'Offsets{$_[0]}+1, 1,
-       || vec $bitmask, $warnings'Offsets{all}+1, 1;
-     warn $msg;
+  if(defined &warnings::warnif_at_level) { # perl >= 5.27.8
+   warnings::warnif_at_level($_[0], $level-1, $_[1]);
+  } else {
+   # In older perl versions (< 5.27.8) there is, unfortunately, no way
+   # to avoid this hack. warnings.pm did not allow us to specify
+   # exactly the call frame we want, so we have to look at the bitmask
+   # ourselves.
+   if(  vec $bitmask, $warnings'Offsets{$_[0]}, 1,
+     || vec $bitmask, $warnings'Offsets{all}, 1,
+     ) {
+      my $msg = $_[1] =~ /\n\z/ ? $_[1] : "$_[1] at $file line $line.\n";
+      die $msg
+       if  vec $bitmask, $warnings'Offsets{$_[0]}+1, 1,
+        || vec $bitmask, $warnings'Offsets{all}+1, 1;
+      warn $msg;
+   }
   }
  }
 }

--- a/lib/DBM/Deep.pod
+++ b/lib/DBM/Deep.pod
@@ -4,7 +4,7 @@ DBM::Deep - A pure perl multi-level hash/array DBM that supports transactions
 
 =head1 VERSION
 
-2.0016
+2.0017
 
 =head1 SYNOPSIS
 

--- a/lib/DBM/Deep.pod
+++ b/lib/DBM/Deep.pod
@@ -4,7 +4,7 @@ DBM::Deep - A pure perl multi-level hash/array DBM that supports transactions
 
 =head1 VERSION
 
-2.0013
+2.0016
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
This PR includes two patches. The first synchronizes the repo with the CPAN version as referenced in https://github.com/robkinyon/dbm-deep/issues/21

The second removes use of apostrophe as a package separator. In perl 5.37.8 this was marked as deprecated and in perl 5.40.0 it will be removed outright.  I also bumped the version to 2.0017. 